### PR TITLE
feat(auth): add OTP login, callback and users guard (no design changes)

### DIFF
--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSession } from '@/lib/auth';
+
+export default function AuthCallbackPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const session = await getSession();
+        router.replace(session ? '/users' : '/login');
+      } catch {
+        router.replace('/login');
+      }
+    })();
+  }, [router]);
+
+  return <div className="p-6 text-sm text-muted-foreground">Completing sign-in…</div>;
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import { signInWithOtp } from '@/lib/auth';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!email) return;
+
+    setStatus('loading');
+    setError(null);
+
+    try {
+      const redirectTo =
+        typeof window !== 'undefined'
+          ? `${window.location.origin}/auth/callback`
+          : '/auth/callback';
+
+      await signInWithOtp({ email, options: { redirectTo } });
+      setStatus('success');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to sign in';
+      setError(message);
+      setStatus('error');
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <div className="w-full max-w-md space-y-6 rounded-xl border bg-card p-6 shadow-sm">
+        <div className="space-y-2 text-center">
+          <h1 className="text-2xl font-semibold">Sign in</h1>
+          <p className="text-sm text-muted-foreground">
+            Enter your email to receive a magic link.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2 text-left">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              autoComplete="email"
+              placeholder="you@example.com"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+            />
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={status === 'loading' || status === 'success'}
+          >
+            {status === 'loading' ? 'Sending magic link…' : 'Send magic link'}
+          </Button>
+        </form>
+
+        {status === 'success' ? (
+          <p className="rounded-md bg-muted p-3 text-sm text-muted-foreground">
+            Check your email to sign in.
+          </p>
+        ) : null}
+
+        {error ? (
+          <p className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,18 +1,49 @@
-// app/users/page.tsx
-import { DashboardLayout } from '@/components/dashboard-layout';
-import UsersTable from '@/components/users-table';
+'use client';
 
-export const metadata = { title: 'Users — Admin' };
+import { useEffect, useState } from 'react';
+import { getSession } from '@/lib/auth';
+import UsersTable from '@/components/users-table';
+import { DashboardLayout } from '@/components/dashboard-layout';
 
 export default function UsersPage() {
+  const [ready, setReady] = useState(false);
+  const [signedIn, setSignedIn] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const session = await getSession();
+        setSignedIn(!!session);
+      } catch {
+        setSignedIn(false);
+      } finally {
+        setReady(true);
+      }
+    })();
+  }, []);
+
   return (
     <DashboardLayout>
-      <main className="p-4 md:p-6 space-y-4">
+      <main className="space-y-4 p-4 md:p-6">
         <div>
           <h1 className="text-xl font-semibold">Users</h1>
-          <p className="text-sm text-muted-foreground">Manage users, organizations and statuses.</p>
+          <p className="text-sm text-muted-foreground">
+            Manage users, organizations and statuses.
+          </p>
         </div>
-        <UsersTable />
+
+        {!ready ? (
+          <div className="text-sm text-muted-foreground">Checking session…</div>
+        ) : !signedIn ? (
+          <div className="rounded-lg border p-4">
+            <div className="font-medium">You must sign in</div>
+            <a className="text-primary underline" href="/login">
+              Go to login
+            </a>
+          </div>
+        ) : (
+          <UsersTable />
+        )}
       </main>
     </DashboardLayout>
   );

--- a/lib/services/client.ts
+++ b/lib/services/client.ts
@@ -74,7 +74,7 @@ async function apiRequest<T>(path: string, method: HttpMethod, init: ApiFetchIni
   if (auth) {
     const token = await getAccessToken();
     if (!token && auth === 'required') {
-      throw new ApiError('Missing auth token', 401, 'NO_TOKEN');
+      throw new ApiError('No auth token available', 401, 'UNAUTHENTICATED');
     }
     if (token) {
       finalHeaders['Authorization'] = `Bearer ${token}`;


### PR DESCRIPTION
## Summary
- add an email OTP login page that triggers Supabase magic links with the existing auth helpers
- handle `/auth/callback` by checking the Supabase session and redirecting accordingly
- gate the `/users` dashboard route behind a client-side session check and improve the API client error when no token is present

## Testing
```
bun x tsc --noEmit

bun run lint
$ eslint

bun run build
$ next build --turbopack
✓ Finished writing to disk in 47ms
Turbopack build encountered 2 warnings:
[next]/internal/font/google/geist_a71539c9.module.css
Error while requesting resource
There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap.

[next]/internal/font/google/geist_mono_8d43a2aa.module.css
Error while requesting resource
There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&display=swap.

> Build error occurred
[Error: Turbopack build failed with 2 errors:
[next]/internal/font/google/geist_a71539c9.module.css
next/font: error:
Failed to fetch `Geist` from Google Fonts.

[next]/internal/font/google/geist_mono_8d43a2aa.module.css
next/font: error:
Failed to fetch `Geist Mono` from Google Fonts.

]
error: script "build" exited with code 1
```


------
https://chatgpt.com/codex/tasks/task_e_68d3005e7f1c832aa1b8fc6237b23795