### PR TITLE
feat(auth): email+password login and platform-admin guard for /users (no design changes)

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { signInWithPassword } from '@/lib/auth';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const { error: authError } = await signInWithPassword({ email, password });
+      if (authError) {
+        setError(authError.message);
+        return;
+      }
+      router.replace('/users');
+    } catch (err) {
+      const fallback = 'Unable to sign in';
+      if (err instanceof Error) {
+        setError(err.message || fallback);
+      } else if (err && typeof err === 'object' && 'message' in err) {
+        const message = (err as { message?: unknown }).message;
+        setError(typeof message === 'string' && message.length > 0 ? message : fallback);
+      } else {
+        setError(fallback);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="p-6 max-w-sm mx-auto space-y-4">
+      <h1 className="text-xl font-semibold">Admin Sign in</h1>
+      <form onSubmit={onSubmit} className="space-y-3">
+        <Input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          required
+          autoComplete="email"
+        />
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          required
+          autoComplete="current-password"
+        />
+        <Button type="submit" disabled={loading} className="w-full">
+          {loading ? 'Signing in…' : 'Sign in'}
+        </Button>
+      </form>
+      {error && <div className="text-sm text-red-600">{error}</div>}
+    </main>
+  );
+}

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,10 +1,34 @@
-// app/users/page.tsx
+'use client';
+
+import { useEffect, useState } from 'react';
 import { DashboardLayout } from '@/components/dashboard-layout';
 import UsersTable from '@/components/users-table';
-
-export const metadata = { title: 'Users — Admin' };
+import { supabaseClient } from '@/lib/supabase';
+import { usePlatformAdminGate } from '@/lib/guards/platform-admin';
 
 export default function UsersPage() {
+  const [readySession, setReadySession] = useState(false);
+  const [signedIn, setSignedIn] = useState(false);
+  const { ready: readyAdmin, isAdmin } = usePlatformAdminGate();
+
+  useEffect(() => {
+    let mounted = true;
+    const supabase = supabaseClient();
+    (async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!mounted) {
+        return;
+      }
+      setSignedIn(!!session);
+      setReadySession(true);
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const ready = readySession && readyAdmin;
+
   return (
     <DashboardLayout>
       <main className="p-4 md:p-6 space-y-4">
@@ -12,7 +36,22 @@ export default function UsersPage() {
           <h1 className="text-xl font-semibold">Users</h1>
           <p className="text-sm text-muted-foreground">Manage users, organizations and statuses.</p>
         </div>
-        <UsersTable />
+
+        {!ready ? (
+          <div className="text-sm text-muted-foreground">Checking access…</div>
+        ) : !signedIn ? (
+          <div className="rounded-lg border p-4">
+            <div className="font-medium mb-1">You must sign in</div>
+            <a className="text-primary underline" href="/login">Go to login</a>
+          </div>
+        ) : !isAdmin ? (
+          <div className="rounded-lg border p-4">
+            <div className="font-medium mb-1">Access denied</div>
+            <p className="text-sm text-muted-foreground">Your account is not a platform admin.</p>
+          </div>
+        ) : (
+          <UsersTable />
+        )}
       </main>
     </DashboardLayout>
   );

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -26,6 +26,11 @@ export async function signInWithOtp({ email, options }: SignInOtpParams) {
   return data;
 }
 
+export async function signInWithPassword(params: { email: string; password: string }) {
+  const supabase = supabaseClient();
+  return supabase.auth.signInWithPassword(params);
+}
+
 export async function signOut() {
   const supabase = supabaseClient();
   const { error } = await supabase.auth.signOut();

--- a/lib/guards/platform-admin.ts
+++ b/lib/guards/platform-admin.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { supabaseClient } from '@/lib/supabase';
+
+export async function isPlatformAdminClient(): Promise<boolean> {
+  const supabase = supabaseClient();
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    return false;
+  }
+  const { data, error } = await supabase.rpc('is_platform_admin');
+  return !error && Boolean(data);
+}
+
+export function usePlatformAdminGate() {
+  const [ready, setReady] = useState(false);
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const ok = await isPlatformAdminClient();
+      if (!mounted) {
+        return;
+      }
+      setIsAdmin(ok);
+      setReady(true);
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return { ready, isAdmin };
+}

--- a/lib/services/client.ts
+++ b/lib/services/client.ts
@@ -71,11 +71,14 @@ async function apiRequest<T>(path: string, method: HttpMethod, init: ApiFetchIni
   }
 
   // JWT
-  if (auth) {
+  if (auth === 'required') {
     const token = await getAccessToken();
-    if (!token && auth === 'required') {
-      throw new ApiError('Missing auth token', 401, 'NO_TOKEN');
+    if (!token) {
+      throw new ApiError('No auth token available', 401, 'UNAUTHENTICATED');
     }
+    finalHeaders['Authorization'] = `Bearer ${token}`;
+  } else if (auth) {
+    const token = await getAccessToken();
     if (token) {
       finalHeaders['Authorization'] = `Bearer ${token}`;
     }


### PR DESCRIPTION
## Summary
- add a credential-based login page that signs in through the existing Supabase auth helpers
- expose a typed `signInWithPassword` helper and add a platform admin guard hook to gate the users area
- gate the `/users` page behind the platform admin check and harden the API client to stop requests without JWTs

## Testing
- ✅ `bun x tsc --noEmit`
- ✅ `bun run lint`
- ⚠️ `bun run build` *(fails locally: Next.js cannot download Google Fonts in the offline sandbox)*
  - last log lines:
    ```
    [next]/internal/font/google/geist_a71539c9.module.css
    next/font: error:
    Failed to fetch `Geist` from Google Fonts.

    [next]/internal/font/google/geist_mono_8d43a2aa.module.css
    next/font: error:
    Failed to fetch `Geist Mono` from Google Fonts.

    error: script "build" exited with code 1
    ```

## Manual verification
1. Vercel: `NEXT_PUBLIC_SUPABASE_URL` e `NEXT_PUBLIC_SUPABASE_ANON_KEY` settate.
2. In Supabase, l’utente `tonellomatias@gmail.com` risulta platform admin (via tabella `platform_admins` o claim).
3. Flusso:
   - Apri `/login`, inserisci email+password → redirect a `/users`.
   - Su `/users` senza login: CTA “You must sign in”.
   - Su `/users` loggato ma non admin: “Access denied”.
   - Da admin: la tabella carica i dati senza “Missing auth token”.


------
https://chatgpt.com/codex/tasks/task_e_68d306ee5970832ab82d38494ba0119b