### PR TITLE
Add platform admin guard and user chip

### DIFF
--- a/app/api/qa/admin-check/route.ts
+++ b/app/api/qa/admin-check/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { createServerClient } from '@supabase/ssr'
+
+type CookieAction = {
+  type: 'set' | 'remove'
+  name: string
+  value?: string
+  options?: Record<string, unknown>
+}
+
+function applyCookieActions(response: NextResponse, actions: CookieAction[]) {
+  actions.forEach((action) => {
+    if (action.type === 'set') {
+      response.cookies.set(action.name, action.value ?? '', action.options)
+    } else {
+      response.cookies.delete(action.name)
+    }
+  })
+}
+
+export async function GET(request: NextRequest) {
+  const actions: CookieAction[] = []
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get: (name: string) => request.cookies.get(name)?.value,
+        set: (name: string, value: string, options?: Record<string, unknown>) => {
+          actions.push({ type: 'set', name, value, options })
+        },
+        remove: (name: string, options?: Record<string, unknown>) => {
+          actions.push({ type: 'remove', name, options })
+        },
+      },
+    }
+  )
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    const response = NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    applyCookieActions(response, actions)
+    return response
+  }
+
+  const email = user.email?.toLowerCase() ?? ''
+  const whitelist = (process.env.PLATFORM_ADMINS ?? '')
+    .toLowerCase()
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+  const isPlatformAdmin = !!email && whitelist.includes(email)
+
+  const response = NextResponse.json({
+    isPlatformAdmin,
+    email: user.email ?? null,
+  })
+  applyCookieActions(response, actions)
+
+  return response
+}

--- a/app/api/v1/me/permissions/route.ts
+++ b/app/api/v1/me/permissions/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { createServerClient } from '@supabase/ssr'
+
+type CookieAction = {
+  type: 'set' | 'remove'
+  name: string
+  value?: string
+  options?: Record<string, unknown>
+}
+
+function applyCookieActions(response: NextResponse, actions: CookieAction[]) {
+  actions.forEach((action) => {
+    if (action.type === 'set') {
+      response.cookies.set(action.name, action.value ?? '', action.options)
+    } else {
+      response.cookies.delete(action.name)
+    }
+  })
+}
+
+export async function GET(request: NextRequest) {
+  const actions: CookieAction[] = []
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get: (name: string) => request.cookies.get(name)?.value,
+        set: (name: string, value: string, options?: Record<string, unknown>) => {
+          actions.push({ type: 'set', name, value, options })
+        },
+        remove: (name: string, options?: Record<string, unknown>) => {
+          actions.push({ type: 'remove', name, options })
+        },
+      },
+    }
+  )
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    const response = NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    applyCookieActions(response, actions)
+    return response
+  }
+
+  const email = user.email?.toLowerCase() ?? ''
+  const whitelist = (process.env.PLATFORM_ADMINS ?? '')
+    .toLowerCase()
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+  const isPlatformAdmin = !!email && whitelist.includes(email)
+
+  const response = NextResponse.json({
+    email: user.email ?? null,
+    permissions: isPlatformAdmin ? ['platform:admin'] : [],
+    role: isPlatformAdmin ? 'platform_admin' : 'user',
+  })
+  applyCookieActions(response, actions)
+
+  return response
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useState, type FormEvent } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useEffect, useState, type FormEvent } from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { signInWithEmailPassword } from '@/lib/auth';
@@ -11,8 +10,13 @@ export default function LoginPage() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const searchParams = useSearchParams();
-  const next = searchParams.get('next') || '/';
+  const [next, setNext] = useState<string>('/');
+
+  useEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search);
+    const target = searchParams.get('next') || '/';
+    setNext(target);
+  }, []);
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,29 +1,36 @@
 'use client';
 
 import { useState, type FormEvent } from 'react';
-import { useRouter } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { signInWithPassword } from '@/lib/auth';
+import { signInWithEmailPassword } from '@/lib/auth';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const router = useRouter();
+  const searchParams = useSearchParams();
+  const next = searchParams.get('next') || '/';
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    setLoading(true);
     setError(null);
+    setLoading(true);
+
     try {
-      const { error: authError } = await signInWithPassword({ email, password });
+      const { error: authError } = await signInWithEmailPassword(email, password);
       if (authError) {
-        setError(authError.message);
+        const message =
+          typeof authError.message === 'string' && authError.message.length > 0
+            ? authError.message
+            : 'Invalid credentials';
+        setError(message);
         return;
       }
-      router.replace('/users');
+
+      window.location.assign(next);
     } catch (err) {
       const fallback = 'Unable to sign in';
       if (err instanceof Error) {

--- a/components/UserChip.tsx
+++ b/components/UserChip.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import { useEffect, useMemo, useState, useCallback } from "react"
+import { useRouter } from "next/navigation"
+
+import { supabaseClient } from "@/lib/supabase"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+type AdminCheckResponse = {
+  email?: string | null
+  isPlatformAdmin?: boolean
+  error?: string
+}
+
+export function UserChip() {
+  const [email, setEmail] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const router = useRouter()
+
+  useEffect(() => {
+    let active = true
+
+    fetch("/api/qa/admin-check")
+      .then(async (response) => {
+        try {
+          return await response.json()
+        } catch {
+          return {}
+        }
+      })
+      .then((data: AdminCheckResponse) => {
+        if (!active) return
+        setEmail(data.email ?? null)
+      })
+      .catch(() => {
+        if (!active) return
+        setEmail(null)
+      })
+      .finally(() => {
+        if (!active) return
+        setLoading(false)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const displayName = useMemo(() => {
+    if (email) {
+      const [localPart] = email.split("@")
+      return localPart || email
+    }
+    return loading ? "Loading" : "Account"
+  }, [email, loading])
+
+  const avatarInitial = useMemo(() => {
+    if (email && email.length > 0) {
+      return email.charAt(0).toUpperCase()
+    }
+    return "?"
+  }, [email])
+
+  const handleLogout = useCallback(async () => {
+    const client = supabaseClient()
+    await client.auth.signOut()
+    router.push("/login")
+  }, [router])
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          className="flex items-center gap-3 bg-transparent px-3 py-2 text-left text-white hover:bg-white/10 focus-visible:ring-0 focus-visible:ring-offset-0"
+        >
+          <div className="text-right">
+            <p className="text-sm font-medium text-white">{displayName}</p>
+            <p className="text-xs text-white/60">
+              {loading ? "Loading..." : email ?? "Not available"}
+            </p>
+          </div>
+          <div className="flex size-8 items-center justify-center rounded-full bg-gradient-to-r from-cyan-400 to-purple-400 text-sm font-semibold text-white">
+            {avatarInitial}
+          </div>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-40">
+        <DropdownMenuItem onClick={handleLogout}>Logout</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import { UserChip } from "@/components/UserChip"
 import { 
   BarChart3, 
   Users, 
@@ -119,13 +120,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
             </div>
           </div>
           
-          <div className="flex items-center space-x-4">
-            <div className="text-right">
-              <p className="text-white text-sm font-medium">Admin User</p>
-              <p className="text-white/60 text-xs">admin@klyra.com</p>
-            </div>
-            <div className="w-8 h-8 bg-gradient-to-r from-cyan-400 to-purple-400 rounded-full"></div>
-          </div>
+          <UserChip />
         </header>
 
         {/* Main content area */}

--- a/env.example
+++ b/env.example
@@ -1,2 +1,3 @@
-NEXT_PUBLIC_SUPABASE_URL=<set-on-vercel>
-NEXT_PUBLIC_SUPABASE_ANON_KEY=<set-on-vercel>
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+PLATFORM_ADMINS=tonellomatias@gmail.com,admin@klyra.com

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { createServerClient } from '@supabase/ssr'
+
+export async function middleware(request: NextRequest) {
+  const res = NextResponse.next()
+
+  const publicPaths = ['/login', '/api/qa/session', '/api/health']
+  const { pathname } = request.nextUrl
+
+  const isPublicPath =
+    publicPaths.includes(pathname) ||
+    pathname.startsWith('/_next/') ||
+    pathname === '/favicon.ico' ||
+    /\.(?:png|jpg|jpeg|svg|ico|css|js|txt|webmanifest)$/.test(pathname)
+
+  if (isPublicPath) {
+    return res
+  }
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get: (name: string) => request.cookies.get(name)?.value,
+        set: (name: string, value: string, options?: Record<string, unknown>) => {
+          res.cookies.set(name, value, options)
+        },
+        remove: (name: string, options?: Record<string, unknown>) => {
+          void options
+          res.cookies.delete(name)
+        },
+      },
+    }
+  )
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    const redirectUrl = new URL('/login', request.url)
+    redirectUrl.searchParams.set('next', pathname)
+    return NextResponse.redirect(redirectUrl)
+  }
+
+  const email = user.email?.toLowerCase() ?? ''
+  const whitelist = (process.env.PLATFORM_ADMINS ?? '')
+    .toLowerCase()
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+  const isAdmin = !!email && whitelist.includes(email)
+
+  if (!isAdmin) {
+    return NextResponse.redirect(new URL('/login?error=access_denied', request.url))
+  }
+
+  return res
+}
+
+export const config = {
+  matcher: [
+    '/((?!_next/|favicon.ico|.*\\.(?:png|jpg|jpeg|svg|ico|css|js|txt|webmanifest)$).*)',
+  ],
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.57.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- add Supabase-based middleware to guard routes for platform admins and redirect unauthenticated users
- expose minimal admin-check and permissions API routes to surface user email and admin flag
- replace the dashboard header user chip with live Supabase data plus logout, and update env/deps for admin allowlist

## Testing
- npm run lint
- npm run build *(fails: Google Fonts download blocked in container)*

## Manual Tests
1. `/` senza sessione ⇒ redirect `/login?next=/`
2. Login utente non admin ⇒ redirect `/login?error=access_denied`
3. Login admin ⇒ dashboard visibile, header mostra email, Logout funziona

## Modified files
A middleware.ts
A app/api/qa/admin-check/route.ts
A app/api/v1/me/permissions/route.ts
A components/UserChip.tsx
M components/dashboard-layout.tsx
M env.example
M package.json

------
https://chatgpt.com/codex/tasks/task_e_68d3e4e732cc832a96cd6e8b6882a29a