### PR TITLE
Implement server-backed admin users listing

### DIFF
--- a/app/api/admin/users/_utils.ts
+++ b/app/api/admin/users/_utils.ts
@@ -1,0 +1,339 @@
+import { createServerClient } from '@supabase/ssr'
+import { createClient } from '@supabase/supabase-js'
+import type { NextRequest } from 'next/server'
+
+export type CookiePayload = {
+  name: string
+  value: string
+  options?: Record<string, unknown>
+}
+
+export type SupabaseAuthUser = {
+  id: string
+  email?: string | null
+}
+
+export type AdminUser = {
+  id: string
+  email?: string | null
+  created_at?: string | null
+  confirmed_at?: string | null
+  email_confirmed_at?: string | null
+  last_sign_in_at?: string | null
+  banned_until?: string | null
+  user_metadata?: Record<string, unknown> | null
+  app_metadata?: Record<string, unknown> | null
+}
+
+export type AdminUserSummary = {
+  id: string
+  email: string
+  display_name?: string
+  created_at?: string
+  status: 'active' | 'invited' | 'disabled'
+  org_name?: string
+  organization?: Record<string, unknown> | null
+  organizations?: Array<Record<string, unknown>> | null
+}
+
+type EnsureAdminSuccess = {
+  ok: true
+  cookies: CookiePayload[]
+  user: SupabaseAuthUser
+  adminClient: ReturnType<typeof createClient>
+}
+
+type EnsureAdminFailure = {
+  ok: false
+  cookies: CookiePayload[]
+  status: number
+  message: string
+}
+
+export type EnsureAdminResult = EnsureAdminSuccess | EnsureAdminFailure
+
+export async function ensureAdmin(request: NextRequest): Promise<EnsureAdminResult> {
+  const cookiesToSet: CookiePayload[] = []
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url || !anonKey || !serviceRole) {
+    return {
+      ok: false,
+      cookies: cookiesToSet,
+      status: 500,
+      message: 'Server configuration error',
+    }
+  }
+
+  const supabase = createServerClient(url, anonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll()
+      },
+      setAll(cookies) {
+        cookies.forEach((cookie) => {
+          cookiesToSet.push(cookie)
+        })
+      },
+    },
+  })
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (!user || userError) {
+    return {
+      ok: false,
+      cookies: cookiesToSet,
+      status: 401,
+      message: 'Unauthorized',
+    }
+  }
+
+  const adminClient = createClient(url, serviceRole, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+
+  const { error: platformError, data: platformRow } = await adminClient
+    .from('platform_admins')
+    .select('user_id')
+    .eq('user_id', user.id)
+    .limit(1)
+    .maybeSingle()
+
+  if (platformError) {
+    return {
+      ok: false,
+      cookies: cookiesToSet,
+      status: 500,
+      message: 'Server error',
+    }
+  }
+
+  if (!platformRow) {
+    return {
+      ok: false,
+      cookies: cookiesToSet,
+      status: 403,
+      message: 'Forbidden',
+    }
+  }
+
+  return {
+    ok: true,
+    cookies: cookiesToSet,
+    user: {
+      id: user.id,
+      email: user.email ?? null,
+    },
+    adminClient,
+  }
+}
+
+function parseBannedUntil(value: string | null | undefined): boolean {
+  if (!value) {
+    return false
+  }
+
+  if (value === 'forever') {
+    return true
+  }
+
+  const timestamp = Date.parse(value)
+  return Number.isFinite(timestamp) && timestamp > Date.now()
+}
+
+export function deriveStatus(user: AdminUser): 'active' | 'invited' | 'disabled' {
+  if (parseBannedUntil(user.banned_until)) {
+    return 'disabled'
+  }
+
+  if (user.email_confirmed_at || user.confirmed_at || user.last_sign_in_at) {
+    return 'active'
+  }
+
+  return 'invited'
+}
+
+function pickString(values: Array<unknown>): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value
+    }
+  }
+  return undefined
+}
+
+export function toUserSummary(user: AdminUser): AdminUserSummary {
+  const metadata = (user.user_metadata ?? {}) as Record<string, unknown>
+
+  const displayName = pickString([
+    metadata.full_name,
+    metadata.name,
+    metadata.display_name,
+    metadata.username,
+  ])
+
+  const summary: AdminUserSummary = {
+    id: user.id,
+    email: typeof user.email === 'string' ? user.email : '',
+    display_name: displayName,
+    created_at: typeof user.created_at === 'string' ? user.created_at : undefined,
+    status: deriveStatus(user),
+  }
+
+  if (typeof metadata.org_name === 'string') {
+    summary.org_name = metadata.org_name
+  }
+
+  if (metadata.organization && typeof metadata.organization === 'object') {
+    summary.organization = metadata.organization as Record<string, unknown>
+  }
+
+  if (Array.isArray(metadata.organizations)) {
+    summary.organizations = metadata.organizations as Array<Record<string, unknown>>
+  }
+
+  return summary
+}
+
+function normalize(value: string): string {
+  return value.normalize('NFKD').toLowerCase()
+}
+
+function matchesQuery(user: AdminUser, query: string): boolean {
+  if (!query) {
+    return true
+  }
+
+  const normalized = normalize(query)
+
+  if (typeof user.email === 'string' && normalize(user.email).includes(normalized)) {
+    return true
+  }
+
+  const metadata = (user.user_metadata ?? {}) as Record<string, unknown>
+  const fields: unknown[] = [
+    metadata.full_name,
+    metadata.name,
+    metadata.display_name,
+    metadata.username,
+    metadata.org_name,
+  ]
+
+  const organization = metadata.organization
+  if (organization && typeof organization === 'object') {
+    const name = (organization as Record<string, unknown>).name
+    fields.push(name)
+  }
+
+  const organizations = metadata.organizations
+  if (Array.isArray(organizations)) {
+    organizations.forEach((entry) => {
+      if (entry && typeof entry === 'object') {
+        fields.push((entry as Record<string, unknown>).name)
+      }
+    })
+  }
+
+  return fields.some((field) => typeof field === 'string' && normalize(field).includes(normalized))
+}
+
+export function filterUsers(
+  users: AdminUser[],
+  options: { query?: string; status?: 'active' | 'invited' | 'disabled' }
+): AdminUser[] {
+  const query = options.query?.trim() ?? ''
+  const status = options.status
+
+  return users.filter((user) => {
+    if (status && deriveStatus(user) !== status) {
+      return false
+    }
+
+    if (query && !matchesQuery(user, query)) {
+      return false
+    }
+
+    return true
+  })
+}
+
+type ListUsersResult = {
+  data?: {
+    users?: AdminUser[]
+    nextPage?: number | null
+    lastPage?: number
+    total?: number
+  }
+  error?: { message?: string } | null
+}
+
+export async function fetchUsersPage(
+  adminClient: ReturnType<typeof createClient>,
+  page: number,
+  perPage: number
+): Promise<{
+  users: AdminUser[]
+  nextPage: number | null
+  total?: number
+}> {
+  const result = (await adminClient.auth.admin.listUsers({
+    page,
+    perPage,
+  })) as ListUsersResult
+
+  const pageUsers = Array.isArray(result.data?.users) ? result.data?.users ?? [] : []
+  const nextPage = typeof result.data?.nextPage === 'number' ? result.data?.nextPage ?? null : null
+  const total = typeof result.data?.total === 'number' ? result.data?.total : undefined
+
+  if (result.error) {
+    const message = result.error?.message ?? 'Failed to list users'
+    throw new Error(message)
+  }
+
+  return {
+    users: pageUsers,
+    nextPage,
+    total,
+  }
+}
+
+export async function fetchAllUsers(
+  adminClient: ReturnType<typeof createClient>,
+  pageSize: number,
+  maxPages = 50
+): Promise<{ users: AdminUser[]; total?: number }> {
+  const allUsers: AdminUser[] = []
+  let total: number | undefined
+  let currentPage = 1
+  let iterations = 0
+  const perPage = Math.max(1, Math.min(pageSize, 100))
+
+  while (iterations < maxPages) {
+    iterations += 1
+    const { users, nextPage, total: pageTotal } = await fetchUsersPage(adminClient, currentPage, perPage)
+    allUsers.push(...users)
+
+    if (typeof pageTotal === 'number') {
+      total = pageTotal
+    }
+
+    if (!nextPage || nextPage === currentPage) {
+      break
+    }
+
+    currentPage = nextPage
+  }
+
+  return { users: allUsers, total }
+}
+

--- a/app/api/admin/users/count/route.ts
+++ b/app/api/admin/users/count/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+import {
+  ensureAdmin,
+  filterUsers,
+  fetchAllUsers,
+  fetchUsersPage,
+  type CookiePayload,
+} from '../_utils'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const MAX_PAGE_SIZE = 100
+
+function applyCookies(response: NextResponse, cookies: CookiePayload[]) {
+  cookies.forEach(({ name, value, options }) => {
+    response.cookies.set({ name, value, ...(options ?? {}) })
+  })
+}
+
+function normalizeStatus(value: string | null): 'active' | 'invited' | 'disabled' | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  if (value === 'active' || value === 'invited' || value === 'disabled') {
+    return value
+  }
+
+  return undefined
+}
+
+export async function GET(request: NextRequest) {
+  const adminResult = await ensureAdmin(request)
+
+  if (!adminResult.ok) {
+    const response = NextResponse.json({ error: adminResult.message }, { status: adminResult.status })
+    applyCookies(response, adminResult.cookies)
+    return response
+  }
+
+  const { adminClient, cookies } = adminResult
+  const { searchParams } = new URL(request.url)
+
+  const query = searchParams.get('q')?.trim() ?? ''
+  const status = normalizeStatus(searchParams.get('status'))
+  const shouldFilter = Boolean(query) || Boolean(status)
+
+  try {
+    if (shouldFilter) {
+      const { users: allUsers } = await fetchAllUsers(adminClient, MAX_PAGE_SIZE)
+      const filtered = filterUsers(allUsers, { query, status })
+
+      const response = NextResponse.json({ total: filtered.length })
+      applyCookies(response, cookies)
+      return response
+    }
+
+    const { users, total } = await fetchUsersPage(adminClient, 1, 1)
+    const resolvedTotal = typeof total === 'number' ? total : users.length
+
+    const response = NextResponse.json({ total: resolvedTotal })
+    applyCookies(response, cookies)
+    return response
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to count users'
+    const response = NextResponse.json({ error: message }, { status: 500 })
+    applyCookies(response, cookies)
+    return response
+  }
+}
+

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+import {
+  ensureAdmin,
+  filterUsers,
+  toUserSummary,
+  fetchAllUsers,
+  fetchUsersPage,
+  type CookiePayload,
+} from './_utils'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const DEFAULT_PER_PAGE = 20
+const MAX_PER_PAGE = 100
+
+function applyCookies(response: NextResponse, cookies: CookiePayload[]) {
+  cookies.forEach(({ name, value, options }) => {
+    response.cookies.set({ name, value, ...(options ?? {}) })
+  })
+}
+
+function parsePositiveInt(value: string | null, fallback: number, max?: number) {
+  if (!value) {
+    return fallback
+  }
+
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback
+  }
+
+  if (max && parsed > max) {
+    return max
+  }
+
+  return parsed
+}
+
+function normalizeStatus(value: string | null): 'active' | 'invited' | 'disabled' | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  if (value === 'active' || value === 'invited' || value === 'disabled') {
+    return value
+  }
+
+  return undefined
+}
+
+export async function GET(request: NextRequest) {
+  const adminResult = await ensureAdmin(request)
+
+  if (!adminResult.ok) {
+    const response = NextResponse.json({ error: adminResult.message }, { status: adminResult.status })
+    applyCookies(response, adminResult.cookies)
+    return response
+  }
+
+  const { adminClient, cookies } = adminResult
+  const { searchParams } = new URL(request.url)
+
+  const page = parsePositiveInt(searchParams.get('page'), 1)
+  const perPage = parsePositiveInt(searchParams.get('perPage'), DEFAULT_PER_PAGE, MAX_PER_PAGE)
+  const query = searchParams.get('q')?.trim() ?? ''
+  const status = normalizeStatus(searchParams.get('status'))
+
+  const shouldFilter = Boolean(query) || Boolean(status)
+
+  try {
+    if (shouldFilter) {
+      const { users: allUsers } = await fetchAllUsers(adminClient, Math.max(perPage, MAX_PER_PAGE))
+      const filtered = filterUsers(allUsers, { query, status })
+
+      const startIndex = Math.max(0, (page - 1) * perPage)
+      const paginated = filtered.slice(startIndex, startIndex + perPage)
+      const nextPage = startIndex + perPage < filtered.length ? page + 1 : null
+
+      const response = NextResponse.json({
+        users: paginated.map((user) => toUserSummary(user)),
+        page,
+        perPage,
+        nextPage,
+        total: filtered.length,
+      })
+      applyCookies(response, cookies)
+      return response
+    }
+
+    const { users, nextPage, total } = await fetchUsersPage(adminClient, page, perPage)
+    const summaries = users.map((user) => toUserSummary(user))
+
+    const computedTotal = typeof total === 'number'
+      ? total
+      : (page - 1) * perPage + summaries.length
+
+    const computedNextPage = typeof total === 'number'
+      ? (page * perPage < total ? page + 1 : null)
+      : (nextPage && nextPage > page ? nextPage : null)
+
+    const response = NextResponse.json({
+      users: summaries,
+      page,
+      perPage,
+      nextPage: computedNextPage,
+      total: computedTotal,
+    })
+    applyCookies(response, cookies)
+    return response
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to load users'
+    const response = NextResponse.json({ error: message }, { status: 500 })
+    applyCookies(response, cookies)
+    return response
+  }
+}
+


### PR DESCRIPTION
## Summary
- add server-only admin users list and count routes that validate platform admins
- reuse Supabase service role to fetch and filter user data before returning sanitized payloads
- update the client users service to consume the new endpoints and expose a count helper

## Testing
- bun lint

------
https://chatgpt.com/codex/tasks/task_e_68d4105441dc832a8d19ce527be80ea7