### PR TITLE
Fetch active user count for dashboard

### DIFF
--- a/lib/hooks/useDashboardMetrics.ts
+++ b/lib/hooks/useDashboardMetrics.ts
@@ -3,7 +3,7 @@
 // Niente dipendenze esterne, solo useState/useEffect.
 
 import { useEffect, useState } from 'react';
-import { getDashboardMetrics, type DashboardMetrics } from '@/lib/services/metrics';
+import { getActiveUsersCount, getDashboardMetrics, type DashboardMetrics } from '@/lib/services/metrics';
 import { ApiError } from '@/lib/services/client';
 
 type Status = 'idle' | 'loading' | 'success' | 'error';
@@ -12,6 +12,9 @@ export function useDashboardMetrics() {
   const [data, setData] = useState<DashboardMetrics | null>(null);
   const [status, setStatus] = useState<Status>('idle');
   const [error, setError] = useState<Error | ApiError | null>(null);
+  const [activeUsers, setActiveUsers] = useState<number | null>(null);
+  const [activeUsersStatus, setActiveUsersStatus] = useState<Status>('idle');
+  const [activeUsersError, setActiveUsersError] = useState<Error | ApiError | null>(null);
 
   useEffect(() => {
     let mounted = true;
@@ -24,6 +27,7 @@ export function useDashboardMetrics() {
         if (!mounted) return;
         setData(res ?? null);
         setStatus('success');
+        setError(null);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (e: any) {
         if (!mounted) return;
@@ -40,5 +44,46 @@ export function useDashboardMetrics() {
     };
   }, []);
 
-  return { data, status, error, isLoading: status === 'loading', isError: status === 'error' };
+  useEffect(() => {
+    let mounted = true;
+    const controller = new AbortController();
+
+    async function loadActiveUsers() {
+      try {
+        setActiveUsersStatus('loading');
+        setActiveUsersError(null);
+        const result = await getActiveUsersCount(controller.signal);
+        if (!mounted) return;
+        setActiveUsers(result.total);
+        setActiveUsersStatus('success');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (e: any) {
+        if (!mounted) return;
+        if (e?.name === 'AbortError') return;
+        setActiveUsers(null);
+        setActiveUsersStatus('error');
+        setActiveUsersError(e instanceof Error ? e : new Error('Failed to load active users count'));
+      }
+    }
+
+    loadActiveUsers();
+
+    return () => {
+      mounted = false;
+      controller.abort();
+    };
+  }, []);
+
+  return {
+    data,
+    status,
+    error,
+    isLoading: status === 'loading',
+    isError: status === 'error',
+    activeUsers,
+    activeUsersStatus,
+    activeUsersError,
+    isActiveUsersLoading: activeUsersStatus === 'loading',
+    isActiveUsersError: activeUsersStatus === 'error',
+  };
 }

--- a/lib/services/metrics.ts
+++ b/lib/services/metrics.ts
@@ -6,6 +6,10 @@
 import { api } from './client';
 
 export type DashboardMetrics = unknown;
+
+export type ActiveUsersCount = {
+  total: number;
+};
 // Suggerimento per futuri refinement tipo:
 // export interface DashboardMetrics {
 //   totalUsers: number;
@@ -27,6 +31,59 @@ export async function getDashboardMetrics(signal?: AbortSignal): Promise<Dashboa
     signal,
     // timeoutMs: 20000 // default dal client; opzionale personalizzare
   });
+}
+
+function parseCountPayload(payload: unknown): ActiveUsersCount {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid response payload');
+  }
+
+  const candidate = payload as { total?: unknown };
+
+  if (typeof candidate.total !== 'number' || Number.isNaN(candidate.total)) {
+    throw new Error('Invalid total value in response');
+  }
+
+  return { total: candidate.total };
+}
+
+export async function getActiveUsersCount(signal?: AbortSignal): Promise<ActiveUsersCount> {
+  const response = await fetch('/api/admin/users/count', {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+    },
+    credentials: 'same-origin',
+    cache: 'no-store',
+    signal,
+  });
+
+  const text = await response.text();
+  let payload: unknown = null;
+
+  if (text.length > 0) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = null;
+    }
+  }
+
+  if (!response.ok) {
+    const payloadRecord = payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : null;
+    const message =
+      payloadRecord && typeof payloadRecord.error === 'string'
+        ? String(payloadRecord.error)
+        : `Failed to fetch active users count (status ${response.status})`;
+
+    throw new Error(message);
+  }
+
+  try {
+    return parseCountPayload(payload);
+  } catch {
+    throw new Error('Invalid active users count response');
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a service-layer helper that calls `/api/admin/users/count` to read the real active user total
- extend `useDashboardMetrics` to fetch the count with dedicated loading and error tracking
- render the live active user total in the metrics cards while keeping the existing UI fallback behaviour

## Testing
- bun lint

## Modified Files
- components/metrics-cards.tsx
- lib/hooks/useDashboardMetrics.ts
- lib/services/metrics.ts

------
https://chatgpt.com/codex/tasks/task_e_68d41e519e84832a882e369925cfa479